### PR TITLE
allow overriding the fluid level capacity value

### DIFF
--- a/nmea2000.orogen
+++ b/nmea2000.orogen
@@ -116,6 +116,11 @@ end
 task_context 'FluidLevelTask' do
     needs_configuration
 
+    # Override the capacity coming from the NMEA2000 device
+    #
+    # It is used instead of the device-reported capacity if non-zero
+    property "capacity", "/float", 0
+
     input_port 'msg_in', '/nmea2000/Message'
 
     output_port 'level_out', '/tank_base/FluidLevel'

--- a/tasks/FluidLevelTask.cpp
+++ b/tasks/FluidLevelTask.cpp
@@ -33,13 +33,15 @@ bool FluidLevelTask::startHook()
 }
 void FluidLevelTask::updateHook()
 {
+    float capacity = _capacity.get();
+
     nmea2000::Message msg;
     while (_msg_in.read(msg) == RTT::NewData) {
         if (msg.pgn == pgns::FluidLevel::ID) {
             auto in = pgns::FluidLevel::fromMessage(msg);
             tank_base::FluidLevel out;
             out.time = in.time;
-            out.currentLevel = in.level / in.capacity;
+            out.currentLevel = in.level / (capacity ? capacity : in.capacity);
             _level_out.write(out);
         }
     }


### PR DESCRIPTION
This value needs to be configured with the vendor-specific tool,
which I am trying to avoid having to use in the first place.