### PR TITLE
airmar: allow overriding the range field sent by the PGN

### DIFF
--- a/nmea2000.orogen
+++ b/nmea2000.orogen
@@ -106,6 +106,11 @@ task_context 'AirmarDST800Task' do
     property 'sensor_frame', 'string', 'depth_sounder'
     property 'water_frame', 'string', 'water'
     property 'ground_frame', 'string', 'ground'
+    # Max depth that can be reported by the sensor
+    #
+    # This overrides the range embedded in the NMEA2000 PGNs, which seems
+    # to be invalid in the Airmar case
+    property "range", "double", 500
 
     output_port 'speed_samples', '/base/samples/RigidBodyState'
     output_port 'depth_samples', '/base/samples/RigidBodyState'

--- a/tasks/AirmarDST800Task.cpp
+++ b/tasks/AirmarDST800Task.cpp
@@ -28,6 +28,8 @@ bool AirmarDST800Task::startHook()
     if (! AirmarDST800TaskBase::startHook()) {
         return false;
     }
+
+    mRange = _range.get();
     return true;
 }
 void AirmarDST800Task::updateHook()
@@ -39,9 +41,12 @@ void AirmarDST800Task::updateHook()
                 pgns::WaterDepth::fromMessage(msg);
             base::samples::RigidBodyState out;
             out.time = in.time;
-            if (in.depth < in.range) {
+
+            double range = base::isUnknown(mRange) ? in.range : mRange;
+            if (in.depth < range) {
                 out.position.z() = in.depth;
             }
+
             out.sourceFrame = _ground_frame.get();
             out.targetFrame = _sensor_frame.get();
             _depth_samples.write(out);

--- a/tasks/AirmarDST800Task.hpp
+++ b/tasks/AirmarDST800Task.hpp
@@ -4,6 +4,7 @@
 #define NMEA2000_AIRMARDST800TASK_TASK_HPP
 
 #include "nmea2000/AirmarDST800TaskBase.hpp"
+#include <base/Float.hpp>
 
 namespace nmea2000{
 
@@ -11,7 +12,7 @@ namespace nmea2000{
      * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
      * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
      * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
-     * 
+     *
      * \details
      * The name of a TaskContext is primarily defined via:
      \verbatim
@@ -25,8 +26,7 @@ namespace nmea2000{
     {
 	friend class AirmarDST800TaskBase;
     protected:
-
-
+        float mRange = base::unknown<float>();
 
     public:
         /** TaskContext constructor for AirmarDST800Task

--- a/test/test_AirmarDST800Task.rb
+++ b/test/test_AirmarDST800Task.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+using_task_library "nmea2000"
+
+describe OroGen.nmea2000.AirmarDST800Task do
+    run_live
+
+    attr_reader :task
+
+    before do
+        @task = syskit_deploy(
+            OroGen.nmea2000.AirmarDST800Task
+                  .deployed_as("task_under_test")
+        )
+
+        @water_depth_pgn = 128_267
+        @sequence_id = 0
+    end
+
+    it "outputs the converted depth" do
+        syskit_configure_and_start(@task)
+        payload = [0, 1100, 0, 2].pack("CL<S<C")
+        depth = expect_execution { nmea2000_write pgn: 128267, payload: payload }
+            .to { have_one_new_sample task.depth_samples_port }
+
+        assert depth.position.x.nan?
+        assert depth.position.y.nan?
+        assert_equal 11, depth.position.z
+    end
+
+    it "validates the depth using on the embedded range" do
+        task.properties.range = Float::NAN
+        syskit_configure_and_start(task)
+        payload = [0, 1100, 0, 1].pack("CL<S<C")
+        depth = expect_execution { nmea2000_write pgn: 128267, payload: payload }
+            .to { have_one_new_sample task.depth_samples_port }
+
+        assert depth.position.x.nan?
+        assert depth.position.y.nan?
+        assert depth.position.z.nan?
+    end
+
+    it "uses the range property as an override to the embedded range" do
+        task.properties.range = 10
+        syskit_configure_and_start(task)
+
+        payload = [0, 1100, 0, 2].pack("CL<S<C")
+        depth = expect_execution { nmea2000_write pgn: 128267, payload: payload }
+            .to { have_one_new_sample task.depth_samples_port }
+
+        assert depth.position.x.nan?
+        assert depth.position.y.nan?
+        assert depth.position.z.nan?
+    end
+
+    def nmea2000_write(time: Time.now, priority: 0, destination: 0xff,
+                       source: 0, pgn:, payload:)
+
+        payload = payload.unpack("C*") if payload.respond_to?(:to_str)
+        message = Types.nmea2000.Message.new(
+            time: time,
+            priority: priority,
+            destination: destination,
+            source: source,
+            pgn: pgn,
+            payload: payload + [0] * (223 - payload.size)
+        )
+        syskit_write task.msg_in_port, message
+    end
+end


### PR DESCRIPTION
The airmar sends -10 as range, which is rather useless