### PR TITLE
fix: Change the AirmarDST800 to report the base::samples::Temperature

### DIFF
--- a/nmea2000.orogen
+++ b/nmea2000.orogen
@@ -120,7 +120,7 @@ task_context 'AirmarDST800Task' do
 
     output_port 'speed_samples', '/base/samples/RigidBodyState'
     output_port 'depth_samples', '/base/samples/RigidBodyState'
-    output_port 'temperature_samples', '/base/Temperature'
+    output_port 'temperature_samples', '/base/samples/Temperature'
     port_driven
 end
 

--- a/tasks/AirmarDST800Task.cpp
+++ b/tasks/AirmarDST800Task.cpp
@@ -55,8 +55,8 @@ void AirmarDST800Task::updateHook()
             pgns::EnvironmentalParametersExt in =
                 pgns::EnvironmentalParametersExt::fromMessage(msg);
 
-            base::Temperature temperature =
-                base::Temperature::fromCelsius(in.temperature);
+            auto temperature = base::samples::Temperature::fromCelsius(base::Time::now(),
+                in.temperature);
             _temperature_samples.write(temperature);
         }
         else if (msg.pgn == pgns::Speed::ID) {


### PR DESCRIPTION
<!--
Depends on:
- [ ] https://github.com/tidewise/bundles-seabots/pull/569
- [ ] https://github.com/tidewise/bundles-wetpaint/pull/1190
-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
