### PR TITLE
feat: Verify the fluid level sensor instance_id

### DIFF
--- a/nmea2000.orogen
+++ b/nmea2000.orogen
@@ -127,6 +127,11 @@ end
 task_context 'FluidLevelTask' do
     needs_configuration
 
+    # The fluid level sensor identification
+    #
+    # It is used to verify from each sensor the msg comes, if it's not -1
+    property "instance_id", "/int", -1
+
     # Override the capacity coming from the NMEA2000 device
     #
     # It is used instead of the device-reported capacity if non-zero

--- a/tasks/FluidLevelTask.cpp
+++ b/tasks/FluidLevelTask.cpp
@@ -6,12 +6,13 @@
 using namespace nmea2000;
 
 FluidLevelTask::FluidLevelTask(std::string const& name)
-    : FluidLevelTaskBase(name) {
+    : FluidLevelTaskBase(name)
+{
 }
 
-FluidLevelTask::~FluidLevelTask() {
+FluidLevelTask::~FluidLevelTask()
+{
 }
-
 
 /// The following lines are template definitions for the various state machine
 // hooks defined by Orocos::RTT. See FluidLevelTask.hpp for more detailed
@@ -19,14 +20,15 @@ FluidLevelTask::~FluidLevelTask() {
 
 bool FluidLevelTask::configureHook()
 {
-    if (! FluidLevelTaskBase::configureHook()) {
+    if (!FluidLevelTaskBase::configureHook()) {
         return false;
     }
+    m_instance_id = _instance_id.get();
     return true;
 }
 bool FluidLevelTask::startHook()
 {
-    if (! FluidLevelTaskBase::startHook()) {
+    if (!FluidLevelTaskBase::startHook()) {
         return false;
     }
     return true;
@@ -39,10 +41,12 @@ void FluidLevelTask::updateHook()
     while (_msg_in.read(msg) == RTT::NewData) {
         if (msg.pgn == pgns::FluidLevel::ID) {
             auto in = pgns::FluidLevel::fromMessage(msg);
-            tank_base::FluidLevel out;
-            out.time = in.time;
-            out.currentLevel = in.level / (capacity ? capacity : in.capacity);
-            _level_out.write(out);
+            if (m_instance_id == -1 || in.instance == m_instance_id) {
+                tank_base::FluidLevel out;
+                out.time = in.time;
+                out.currentLevel = in.level / (capacity ? capacity : in.capacity);
+                _level_out.write(out);
+            }
         }
     }
     FluidLevelTaskBase::updateHook();

--- a/tasks/FluidLevelTask.cpp
+++ b/tasks/FluidLevelTask.cpp
@@ -41,11 +41,14 @@ void FluidLevelTask::updateHook()
     while (_msg_in.read(msg) == RTT::NewData) {
         if (msg.pgn == pgns::FluidLevel::ID) {
             auto in = pgns::FluidLevel::fromMessage(msg);
-            if (m_instance_id == -1 || in.instance == m_instance_id) {
+            if (m_instance_id == ANY_INSTANCE_ID || in.instance == m_instance_id) {
                 tank_base::FluidLevel out;
                 out.time = in.time;
-                out.currentLevel = in.level / (capacity ? capacity : in.capacity);
-                _level_out.write(out);
+                float const total_capacity = (capacity ? capacity : in.capacity);
+                if (total_capacity > 0) {
+                    out.currentLevel = in.level / total_capacity;
+                    _level_out.write(out);
+                }
             }
         }
     }

--- a/tasks/FluidLevelTask.hpp
+++ b/tasks/FluidLevelTask.hpp
@@ -5,13 +5,16 @@
 
 #include "nmea2000/FluidLevelTaskBase.hpp"
 
-namespace nmea2000{
+namespace nmea2000 {
 
     /*! \class FluidLevelTask
-     * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
-     * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
-     * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
-     * 
+     * \brief The task context provides and requires services. It uses an ExecutionEngine
+     to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These
+     interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the
+     associated workflow.
+     *
      * \details
      * The name of a TaskContext is primarily defined via:
      \verbatim
@@ -19,25 +22,27 @@ namespace nmea2000{
          task('custom_task_name','nmea2000::FluidLevelTask')
      end
      \endverbatim
-     *  It can be dynamically adapted when the deployment is called with a prefix argument.
+     *  It can be dynamically adapted when the deployment is called with a prefix
+     argument.
      */
-    class FluidLevelTask : public FluidLevelTaskBase
-    {
-	friend class FluidLevelTaskBase;
+    class FluidLevelTask : public FluidLevelTaskBase {
+        friend class FluidLevelTaskBase;
+
     protected:
-
-
+    private:
+        int m_instance_id;
 
     public:
         /** TaskContext constructor for FluidLevelTask
-         * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
-         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         * \param name Name of the task. This name needs to be unique to make it
+         * identifiable via nameservices. \param initial_state The initial TaskState of
+         * the TaskContext. Default is Stopped state.
          */
         FluidLevelTask(std::string const& name = "nmea2000::FluidLevelTask");
 
         /** Default deconstructor of FluidLevelTask
          */
-	~FluidLevelTask();
+        ~FluidLevelTask();
 
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the
@@ -100,4 +105,3 @@ namespace nmea2000{
 }
 
 #endif
-

--- a/tasks/FluidLevelTask.hpp
+++ b/tasks/FluidLevelTask.hpp
@@ -30,6 +30,7 @@ namespace nmea2000 {
 
     protected:
     private:
+        static const int ANY_INSTANCE_ID = -1;
         int m_instance_id;
 
     public:


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
The osculati fluid level sensor has the instance number variable that is the tank id.
Now, the FluidLevelTask should be able to identify from each sensor the message comes from and only report messages that match the set instance_id.
[sc-86902]

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
